### PR TITLE
Fix RawCourse to reflect JSON name change from allCoursework to coursework.

### DIFF
--- a/mimir-downloader/src/main/java/com/amann/mimir_downloader/data/json/RawCourse.java
+++ b/mimir-downloader/src/main/java/com/amann/mimir_downloader/data/json/RawCourse.java
@@ -7,7 +7,7 @@ import com.google.gson.annotations.SerializedName;
 public final class RawCourse {
   @SerializedName("course")
   private RawCourseMetadata metadata;
-  @SerializedName("allCoursework")
+  @SerializedName("coursework")
   private List<CourseAssignmentMetadata> assignments;
 
   public List<CourseAssignmentMetadata> getAssignments() {


### PR DESCRIPTION
It appears the JSON format has changed slightly, and I was getting a NullPointerException when trying to access `raw.getAssignments()`.